### PR TITLE
feat: Add spam, photoart and new comer v2 feed. Fix the broken response JSON format.

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -60,17 +60,25 @@ export async function getSuggestedPostsByName(name: string) {
 		// .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
 }
 
-export async function getFeedPostsByName(strategy: string, personalHandle?: string) {
+export async function getFeedPostsByName(strategy: string, isV2: boolean, personalHandle?: string,) {
+	let apiHost = backendUrl;
+	if (isV2) {
+		apiHost = 'https://lensv2-api.k3l.io'
+	}
 
 	if (strategy === 'personal') {
-		const results = await fetch(`${backendUrl}/feed/${strategy}/${personalHandle}`)
+		const results = await fetch(`${apiHost}/feed/${strategy}/${personalHandle}`)
 		.then((r: any) => r.json())
 
 			return results
 	}
 
+	let url = `${apiHost}/feed/${strategy}`;
+	if (strategy === 'newcomer' || strategy === 'spam') {
+		url = `${url}?rankLimit=999999`
+	}
 
-	const results = await fetch(`${backendUrl}/feed/${strategy}`)
+	const results = await fetch(url)
 		.then((r: any) => r.json())
 
 	return results
@@ -89,6 +97,6 @@ export const getContent = async (contentUri: string) => {
 	return results
 }
 
-// https://lens-api.k3l.io/suggest_posts\?handle\=willcollier.lens 
+// https://lens-api.k3l.io/suggest_posts\?handle\=willcollier.lens
 
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -6,12 +6,67 @@ export interface Profile {
 	createdAt: string
 }
 
+enum MainContentFocus {
+	Mint = "MINT",
+	Image = "IMAGE",
+	TextOnly = "TEXT_ONLY",
+	Embed = "EMBED",
+	Video = "VIDEO",
+}
+
+interface ContentHeyOrOrb {
+	id: string,
+	appId: string; // "Hey", "orb"
+	locale: string,
+	mainContentFocus: MainContentFocus;
+	image?: {
+		item: string; // ipfs://
+		type: string; // "image/png"
+	},
+	title?: string;
+	content: string;
+	attachments?: [{
+		item: string; // ipfs://
+		type: string; // "image/png"
+		cover: string; // ipfs://
+	}],
+	video?: {
+		item: string; // "ipfs://
+		type: string; // "video/mp4",
+		duration: number;
+	},
+	embed?: string //
+}
+
 export interface Content {
-	image: string,
-	content: string,
+	image?: string,
+	content?: string,
 	tags: string[],
 	name: string,
 	external_url: string
+	lens?: ContentHeyOrOrb
+}
+
+export interface NormalizedContent {
+	image?: string,
+	content?: string,
+	tags: string[],
+	name: string,
+	external_url: string
+	title?: string;
+}
+
+function normalizeContent(content: Content): NormalizedContent {
+	let normalizeContent = {...content}
+
+	if (content.lens) {
+		normalizeContent.content = content.lens.content
+		if (content.lens.image) {
+			normalizeContent.image = content.lens.image.item
+		}
+	}
+
+	return normalizeContent
 }
 
 // Since v1.5.1 you're now able to call the init function for the web version without options. The current URL path will be used by default. This is recommended when running from a gateway.
@@ -88,13 +143,15 @@ export async function getFeedPostsByName(strategy: string, isV2: boolean, person
 
 export const getContent = async (contentUri: string) => {
 	if (contentUri.indexOf('ar://') !== -1) {
-		return resolveArLink(contentUri)
+		const content = await resolveArLink(contentUri)
+		return normalizeContent(content)
 	}
 
 	const results = await withRetry(() => fetch(contentUri))
 		.then((r: any) => r.json())
 	// @ts-ignore
-	return results
+
+	return normalizeContent(results)
 }
 
 // https://lens-api.k3l.io/suggest_posts\?handle\=willcollier.lens

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,3 +1,14 @@
+export enum Strategy {
+	Personal = 'personal',
+	Recent = 'recent',
+	Popular = 'popular',
+	Recommended = 'recommended',
+	Crowdsourced = 'crowdsourced',
+	PhotographyAndArt = 'photoart',
+	NewComer = 'newcomer',
+	Spam = 'spam',
+}
+
 export interface Profile {
 	id: string,
 	timestamp: string,
@@ -121,7 +132,7 @@ export async function getFeedPostsByName(strategy: string, isV2: boolean, person
 		apiHost = 'https://lensv2-api.k3l.io'
 	}
 
-	if (strategy === 'personal') {
+	if (strategy === Strategy.Personal) {
 		const results = await fetch(`${apiHost}/feed/${strategy}/${personalHandle}`)
 		.then((r: any) => r.json())
 
@@ -129,7 +140,7 @@ export async function getFeedPostsByName(strategy: string, isV2: boolean, person
 	}
 
 	let url = `${apiHost}/feed/${strategy}`;
-	if (strategy === 'newcomer' || strategy === 'spam') {
+	if (strategy === Strategy.NewComer || strategy === Strategy.Spam) {
 		url = `${url}?rankLimit=999999`
 	}
 

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -3,7 +3,8 @@ import {
 	getFeedPostsByName,
 	getSuggestedPostsByName,
 	PER_PAGE,
-	Profile
+	Profile,
+	Strategy,
 } from '../api/api'
 
 import Pagination from './Pagination'
@@ -54,7 +55,7 @@ export default function List(props: any) {
 	const { state: loaderState, dispatch: loaderActions } = useLoaderProvider()
 
 
-	const filterData = useCallback(({ strategy, isV2 }: { strategy: string, isV2: boolean }) => {
+	const filterData = useCallback(({ strategy, isV2 }: { strategy: Strategy, isV2: boolean }) => {
 		setWindowParam('strategy', strategy)
 		setWindowParam('personalHandle', personalHandle)
 		setWindowParam('isV2', isV2 ? 'true' : 'false');
@@ -129,13 +130,13 @@ export default function List(props: any) {
 				<br />
 				<div className="strategy-btn-wrapper">
 					{[
-						{ name: 'Recent', strategy: 'recent', isDisabled: false, isV2: false },
-						{ name: 'Popular', strategy: 'popular', isDisabled: false, isV2: false },
-						{ name: 'Recommended', strategy: 'recommended', isDisabled: false, isV2: false },
+						{ name: 'Recent', strategy: Strategy.Recent, isDisabled: false, isV2: false },
+						{ name: 'Popular', strategy: Strategy.Popular, isDisabled: false, isV2: false },
+						{ name: 'Recommended', strategy: Strategy.Recommended, isDisabled: false, isV2: false },
 						// { name: 'Crowdsourced', strategy: 'crowdsourced', isDisabled: false, isV2: false }, // currently same result as recent
-						{ name: 'Photography & Art', strategy: 'photoart', isDisabled: false, isV2: true },
-						{ name: 'New Comer', strategy: 'newcomer', isDisabled: false, isV2: true },
-						{ name: 'Spam', strategy: 'spam', isDisabled: false, isV2: true },
+						{ name: 'Photography & Art', strategy: Strategy.PhotographyAndArt, isDisabled: false, isV2: true },
+						{ name: 'New Comer', strategy: Strategy.NewComer, isDisabled: false, isV2: true },
+						{ name: 'Spam', strategy: Strategy.Spam, isDisabled: false, isV2: true },
 					].map(btn => {
 						return <>
 							<Tooltip text={'Coming Soon'} isActive={btn.isDisabled} key={btn.strategy}>
@@ -162,14 +163,14 @@ export default function List(props: any) {
 								return
 							}
 
-							filterData({ strategy: 'personal', isV2: false })
+							filterData({ strategy: Strategy.Personal, isV2: false })
 						}}
 						className="strategy-input"
 						type="text" placeholder="Enter your handle" />
 					<div
 
-						onClick={() => filterData({ strategy: 'personal', isV2: false })}
-						className={"strategy-btn" + (search === 'personal' ? ' active-strategy-btn' : '')}
+						onClick={() => filterData({ strategy: Strategy.Personal, isV2: false })}
+						className={"strategy-btn" + (search === Strategy.Personal ? ' active-strategy-btn' : '')}
 						style={{ textTransform: 'capitalize', marginLeft: -410, height: 32, marginTop: 4, boxShadow: 'none', border: '1px solid lightgrey' }}>
 						Following</div>
 				</div>

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { getContent, Content } from '../api/api'
+import { getContent, NormalizedContent } from '../api/api'
 import { ipfsGateway } from '../api/ipfs'
 import moment from 'moment'
 import Linkify from 'react-linkify';
@@ -7,7 +7,7 @@ import Linkify from 'react-linkify';
 export const Post = (props: any) => {
     const post = props.data
     // const isLast = props.isLast
-    const [details, setDetails] = useState({ tags: [''] } as Content)
+    const [details, setDetails] = useState({ tags: [''] } as NormalizedContent)
     const [hideImage, setHideImage] = useState(false)
 
     useEffect(() => {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -9,7 +9,7 @@ export const Search = (props: any) => {
     const [suggestions, setSuggestions] = useState([] as any)
 
     const handleSuggestionClick = (suggestion: any) => {
-        cb(suggestion)
+        cb({strategy: suggestion, isV2: false})
         setSearch(suggestion)
         setSuggestions([])
     }


### PR DESCRIPTION
I noticed that `master` points to https://content.lensv2.k3l.io/ and `main` points to https://content.lens.k3l.io/. This PR is intended to deployed to `main` as it allows you to fetch both v1 and v2 changes. 

Ticket: https://www.notion.so/karma3labs/da499bd9742c44de9f1a20dc384af1eb?v=1305048ea2f74ca780c38c9dd30b506a&p=76c57129678d4b2fa83d4f5bc050b8bf&pm=s

I've also had to make some change on the content uri response to account as new contents from Hey and Orb were returning with a different JSON format. 

Ticket: https://www.notion.so/karma3labs/Update-the-broken-lens-api-response-84497b9488284ebc8ba48fc70dbd0317?pvs=4  

I've subsequently created a new ticket to display video or embed type of posts.

Ticket:https://www.notion.so/karma3labs/Update-the-content-response-shape-to-account-for-video-and-embed-211c4702fdaa4647826124d96df8aec2?pvs=4